### PR TITLE
Update binary download link

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -28,7 +28,7 @@ onInstall:
 actions:
   setupSpeedtest:
     - cmd [vds]: |-
-        wget https://bintray.com/ookla/rhel/rpm -O /etc/yum.repos.d/bintray-ookla-rhel.repo
+        curl -s https://install.speedtest.net/app/cli/install.rpm.sh | sudo bash
         sudo yum install speedtest 
 
       user: root


### PR DESCRIPTION
from speedtest documentation : https://www.speedtest.net/fr/apps/cli 

```
## If migrating from prior bintray install instructions please first...
# sudo rm /etc/yum.repos.d/bintray-ookla-rhel.repo
# sudo yum remove speedtest
## Other non-official binaries will conflict with Speedtest CLI
# Example how to remove using yum
# rpm -qa | grep speedtest | xargs -I {} sudo yum -y remove {}
curl -s https://install.speedtest.net/app/cli/install.rpm.sh | sudo bash
sudo yum install speedtest
``` 
resolves #1 